### PR TITLE
Update semserver to do a case-insensitive change-type check

### DIFF
--- a/src/semver.ts
+++ b/src/semver.ts
@@ -52,7 +52,7 @@ export type ValidIncrementLevel = typeof VALID_INCREMENT_LEVELS[number];
 export const isValidIncrementLevel = (
 	level: string,
 ): level is ValidIncrementLevel => {
-	return _.includes(VALID_INCREMENT_LEVELS, level);
+	return _.includes(VALID_INCREMENT_LEVELS, level.toLowerCase());
 };
 
 /**
@@ -83,8 +83,14 @@ export const getHigherIncrementLevel = (
 		return null;
 	}
 
-	const firstLevelIndex = _.indexOf(VALID_INCREMENT_LEVELS, firstLevel);
-	const secondLevelIndex = _.indexOf(VALID_INCREMENT_LEVELS, secondLevel);
+	const firstLevelIndex = _.indexOf(
+		VALID_INCREMENT_LEVELS,
+		firstLevel?.toLowerCase(),
+	);
+	const secondLevelIndex = _.indexOf(
+		VALID_INCREMENT_LEVELS,
+		secondLevel?.toLowerCase(),
+	);
 
 	return VALID_INCREMENT_LEVELS[Math.max(firstLevelIndex, secondLevelIndex)];
 };

--- a/tests/presets.spec.js
+++ b/tests/presets.spec.js
@@ -3237,9 +3237,22 @@ describe('Presets', function () {
 				m.chai.expect(incrementLevel).to.equal('patch');
 			});
 
-			it('should extract increment level from commit subject', () => {
+			it('should extract increment level from commit subject lower case', () => {
 				const data = {
 					subject: 'patch: subject',
+					footer: {
+						foo: 'bar',
+					},
+				};
+				const incrementLevel = presets.getIncrementLevelFromCommit[
+					'change-type-or-subject'
+				]({}, data);
+				m.chai.expect(incrementLevel).to.equal('patch');
+			});
+
+			it('should extract increment level from commit subject titled', () => {
+				const data = {
+					subject: 'Patch: subject',
 					footer: {
 						foo: 'bar',
 					},

--- a/tests/versionist.spec.js
+++ b/tests/versionist.spec.js
@@ -322,11 +322,30 @@ describe('Versionist', function () {
 				.to.throw('No commits to calculate the next increment level from');
 		});
 
-		it('should calculate the next version', function () {
+		it('should calculate the next version lower case', function () {
 			const nextVersion = versionist.calculateNextVersion(
 				[
 					{
 						subject: 'major foo bar',
+					},
+				],
+				{
+					currentVersion: '1.0.0',
+					incrementVersion: _.partial(presets.incrementVersion.semver, {}),
+					getIncrementLevelFromCommit: (commit) => {
+						return _.first(_.split(commit.subject, ' '));
+					},
+				},
+			);
+
+			m.chai.expect(nextVersion).to.equal('2.0.0');
+		});
+
+		it('should calculate the next version titled', function () {
+			const nextVersion = versionist.calculateNextVersion(
+				[
+					{
+						subject: 'Major foo bar',
 					},
 				],
 				{


### PR DESCRIPTION
Continuation of #184, updated `semserver` validation and added a couple of tests.

Change-type: minor
Signed-off-by: Stathis Moraitidis <stathis@balena.io>