### PR TITLE
Make subject change-type check stricter

### DIFF
--- a/src/presets.js
+++ b/src/presets.js
@@ -448,7 +448,7 @@ module.exports = {
 			if (!_.isString(commit.subject)) {
 				return null;
 			}
-			const match = commit.subject.match(/(patch|minor|major)/i);
+			const match = commit.subject.match(/^(patch|minor|major):/i);
 			if (_.isArray(match) && isIncrementalCommit(match[1])) {
 				return match[1].trim().toLowerCase();
 			}

--- a/tests/presets.spec.js
+++ b/tests/presets.spec.js
@@ -3263,6 +3263,32 @@ describe('Presets', function () {
 				m.chai.expect(incrementLevel).to.equal('patch');
 			});
 
+			it('should not extract increment level from commit subject if not at start', () => {
+				const data = {
+					subject: 'subject patching',
+					footer: {
+						foo: 'bar',
+					},
+				};
+				const incrementLevel = presets.getIncrementLevelFromCommit[
+					'change-type-or-subject'
+				]({}, data);
+				m.chai.expect(incrementLevel).to.not.equal('patch');
+			});
+
+			it('should not extract increment level from commit subject if missing colon', () => {
+				const data = {
+					subject: 'Patch subject',
+					footer: {
+						foo: 'bar',
+					},
+				};
+				const incrementLevel = presets.getIncrementLevelFromCommit[
+					'change-type-or-subject'
+				]({}, data);
+				m.chai.expect(incrementLevel).to.not.equal('patch');
+			});
+
 			it('should prefer increment level from footers over the one in the title', () => {
 				const data = {
 					subject: 'minor: subject',

--- a/tests/versionist.spec.js
+++ b/tests/versionist.spec.js
@@ -181,13 +181,13 @@ describe('Versionist', function () {
 					versionist.calculateNextVersion(
 						[
 							{
-								subject: 'major foo bar',
+								subject: 'major: foo bar',
 							},
 						],
 						{
 							incrementVersion: _.partial(presets.incrementVersion.semver, {}),
 							getIncrementLevelFromCommit: (commit) => {
-								return _.first(_.split(commit.subject, ' '));
+								return presets.getIncrementLevelFromCommit.subject({}, commit);
 							},
 						},
 					);
@@ -326,14 +326,14 @@ describe('Versionist', function () {
 			const nextVersion = versionist.calculateNextVersion(
 				[
 					{
-						subject: 'major foo bar',
+						subject: 'major: foo bar',
 					},
 				],
 				{
 					currentVersion: '1.0.0',
 					incrementVersion: _.partial(presets.incrementVersion.semver, {}),
 					getIncrementLevelFromCommit: (commit) => {
-						return _.first(_.split(commit.subject, ' '));
+						return presets.getIncrementLevelFromCommit.subject({}, commit);
 					},
 				},
 			);
@@ -345,14 +345,14 @@ describe('Versionist', function () {
 			const nextVersion = versionist.calculateNextVersion(
 				[
 					{
-						subject: 'Major foo bar',
+						subject: 'Major: foo bar',
 					},
 				],
 				{
 					currentVersion: '1.0.0',
 					incrementVersion: _.partial(presets.incrementVersion.semver, {}),
 					getIncrementLevelFromCommit: (commit) => {
-						return _.first(_.split(commit.subject, ' '));
+						return presets.getIncrementLevelFromCommit.subject({}, commit);
 					},
 				},
 			);


### PR DESCRIPTION
Subject change-type check was very loose before, now the subject needs to start with case-insensitive major|minor|patch, followed by a colon in order for the type to be parsed.

Change-type: patch
Signed-off-by: Stathis Moraitidis <stathis@balena.io>