### PR TITLE
Update nested package-lock version

### DIFF
--- a/src/presets.js
+++ b/src/presets.js
@@ -865,6 +865,36 @@ module.exports = {
 							},
 						);
 					},
+					(done) =>
+						readJSON(packageLockJSON, (readError, pljObj) => {
+							if (readError && readError.code === 'ENOENT') {
+								return done(null);
+							}
+
+							if (
+								pljObj.lockfileVersion >= 2 &&
+								pljObj.packages &&
+								pljObj.packages[''] &&
+								pljObj.packages[''].version
+							) {
+								pljObj.packages[''].version = cleanedVersion;
+								updateJSON(
+									packageLockJSON,
+									{
+										packages: pljObj.packages,
+									},
+									(updateError) => {
+										if (updateError && updateError.code === 'ENOENT') {
+											return done(null);
+										}
+										return done(updateError);
+									},
+								);
+							} else {
+								return done(null);
+							}
+						}),
+
 					(done) => {
 						updateJSON(
 							npmShrinkwrapJSON,

--- a/tests/presets.spec.js
+++ b/tests/presets.spec.js
@@ -1095,6 +1095,74 @@ describe('Presets', function () {
 				});
 			});
 
+			describe('given package-lock.json of lockfileVersion: 2 exists', function () {
+				beforeEach(function () {
+					this.cwd = tmp.dirSync();
+					this.packageJSON = path.join(this.cwd.name, 'package.json');
+					this.packageLockJSON = path.join(this.cwd.name, 'package-lock.json');
+
+					fs.writeFileSync(
+						this.packageJSON,
+						JSON.stringify(
+							{
+								name: 'foo',
+								version: '1.0.0',
+							},
+							null,
+							2,
+						),
+					);
+					fs.writeFileSync(
+						this.packageLockJSON,
+						JSON.stringify(
+							{
+								name: 'foo',
+								version: '1.0.0',
+								lockfileVersion: 2,
+								packages: {
+									'': {
+										version: '1.0.0',
+									},
+								},
+							},
+							null,
+							2,
+						),
+					);
+				});
+
+				afterEach(function () {
+					fs.unlinkSync(this.packageJSON);
+					fs.unlinkSync(this.packageLockJSON);
+					this.cwd.removeCallback();
+				});
+
+				it('should be able to update the nested version', function (done) {
+					presets.updateVersion.npm({}, this.cwd.name, '1.1.0', (error) => {
+						m.chai.expect(error).to.not.exist;
+
+						const packageLockJSON = JSON.parse(
+							fs.readFileSync(this.packageLockJSON, {
+								encoding: 'utf8',
+							}),
+						);
+
+						m.chai.expect(packageLockJSON).to.deep.equal({
+							name: 'foo',
+							version: '1.1.0',
+							lockfileVersion: 2,
+							packages: {
+								'': {
+									version: '1.1.0',
+								},
+							},
+						});
+
+						done();
+					});
+				});
+			});
+
 			describe('given npm-shrinkwrap.json does not exist', function () {
 				beforeEach(function () {
 					this.cwd = tmp.dirSync();


### PR DESCRIPTION
Updates the nested `packages[""].version` in the same way as the root version. I don't know if this key will exist in following `lockfileVersion`s, there is an explicit check for it. Also not sure under what node version this code will be run (need to update a couple of other packages that have this dependency) so check is not using the optional chaining operator (?.).

Change-type: minor
Signed-off-by: Stathis Moraitidis <stathis@balena.io>