### PR TITLE
patch: Resolve missing blockquote

### DIFF
--- a/src/presets.js
+++ b/src/presets.js
@@ -59,6 +59,7 @@ const templateDefaults = [
         '{{#each this.nested}}',
           '{{> commits nesting=(append ../nesting "#") block=(append ../block ">") }}',
         '{{/each}}',
+      '{{> block-newline}}',
       '{{> block-prefix}}</details>',
       '{{> block-newline}}',
     '{{~else~}}',

--- a/tests/cli/cases/nested-changelog.js
+++ b/tests/cli/cases/nested-changelog.js
@@ -106,6 +106,7 @@ m.chai
 			'> ',
 			'> * qux [Test]',
 			'> ',
+			'',
 			'</details>',
 			'',
 			'* feat: implement x',


### PR DESCRIPTION
While using Changelogs generated by versionbot through a parser. There occured an issue of missing blockquotes with the following error message: 


```
SyntaxError: /home/vipulgupta2048/work/docusaurous/docs/CHANGELOG.md: Expected corresponding JSX closing tag for <blockquote>. (75:0)
  73 | <li parentName="ul">{`Upgrade to postgres 13 `}{`[Pagan Gazzard]`}</li>
  74 | </ul>
> 75 | </details>
     | ^
  76 | </blockquote>
  77 | <details>
  78 | <summary> chore(deps): updated open-balena-s3 to 2.13.3 [Bart Versluijs] </summary>
client (webpack 5.74.0) compiled with 1 error
```

This PR is aimed towards fixing all Changelogs having this issue. 

Signed-off-by: Vipul Gupta (@vipulgupta2048) <vipul@balena.io>
