### PR TITLE
Add support for cargo workspaces

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "lodash": "^4.17.21",
         "markdown": "^0.5.0",
         "replace-in-file": "^4.3.1",
+        "smol-toml": "^1.4.2",
         "yaml": "^2.1.3",
         "yargs": "^11.1.1"
       },
@@ -5911,6 +5912,18 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/smol-toml": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.4.2.tgz",
+      "integrity": "sha512-rInDH6lCNiEyn3+hH8KVGFdbjc099j47+OSgbMrfDYX1CmXLfdKd7qi6IfcWj2wFxvSVkuI46M+wPGYfEOEj6g==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/cyyynthia"
+      }
+    },
     "node_modules/snapdragon": {
       "version": "0.8.2",
       "resolved": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.2.tgz",
@@ -11790,6 +11803,11 @@
           "dev": true
         }
       }
+    },
+    "smol-toml": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.4.2.tgz",
+      "integrity": "sha512-rInDH6lCNiEyn3+hH8KVGFdbjc099j47+OSgbMrfDYX1CmXLfdKd7qi6IfcWj2wFxvSVkuI46M+wPGYfEOEj6g=="
     },
     "snapdragon": {
       "version": "0.8.2",

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "lodash": "^4.17.21",
     "markdown": "^0.5.0",
     "replace-in-file": "^4.3.1",
+    "smol-toml": "^1.4.2",
     "yaml": "^2.1.3",
     "yargs": "^11.1.1"
   },

--- a/src/presets.js
+++ b/src/presets.js
@@ -33,6 +33,7 @@ const yaml = require('yaml');
 const execSync = require('child_process').execSync;
 const { Octokit } = require('@octokit/rest');
 const childProcess = require('child_process');
+const TOML = require('smol-toml');
 
 const octokit = new Octokit({
 	debug: Boolean(process.env.DEBUG),
@@ -1004,11 +1005,9 @@ module.exports = {
 					},
 
 					(contents, done) => {
-						// Check if this is a workspace
-						const workspaceMatch = contents.match(/\[workspace\]/m);
-						const packageMatch = contents.match(/\[package\]/m);
+						const config = TOML.parse(contents);
 
-						if (workspaceMatch && packageMatch) {
+						if (config.workspace != null && config.package != null) {
 							// Versionist doesn't support both workspace and package sections as both
 							// could have different versions and the module would not know which one to update
 							return done(
@@ -1018,98 +1017,81 @@ module.exports = {
 							);
 						}
 
-						if (workspaceMatch) {
+						if (config.workspace != null) {
 							// For workspaces, extract member names from the members array
-							const membersMatch = contents.match(/members\s*=\s*\[(.*?)\]/s);
-							if (membersMatch) {
-								// Extract member names from the array
-								const membersStr = membersMatch[1];
-								const memberMatches = membersStr.match(/"([^"]+)"/g);
-								if (memberMatches) {
-									const members = memberMatches.map((m) => m.slice(1, -1));
-									done(null, { isWorkspace: true, members });
-								} else {
-									done(null, { isWorkspace: true, members: [] });
+							const members = config.workspace.members ?? [];
+							if (config.workspace.package == null) {
+								return done(
+									new Error(
+										`Missing 'workspace.package' section in Cargo.toml`,
+									),
+								);
+							}
+
+							if (config.workspace.package.version == null) {
+								done(
+									new Error(
+										`Missing property 'workspace.package.version' in Cargo.toml`,
+									),
+								);
+							}
+
+							done(null, { config, members });
+						} else if (config.package != null) {
+							// validate necessary properties exist under the package section
+							for (const prop of ['name', 'version']) {
+								if (!config.package.hasOwnProperty(prop)) {
+									return done(
+										new Error(
+											`Missing property 'package.${prop}' in Cargo.toml`,
+										),
+									);
 								}
-							} else {
-								done(null, { isWorkspace: true, members: [] });
 							}
+
+							done(null, { config, members: [config.package.name] });
 						} else {
-							// Regular package - capture first `name = "..."` occurrence immediately after `[package]`
-							const matches = contents.match(
-								/\[package\][^[]+?name\s*=\s*("|')(.+?)\1/m,
+							done(
+								new Error(
+									`No [workspace] or [package] sections found in Cargo.toml.`,
+								),
 							);
-							if (_.isNull(matches)) {
-								done(new Error(`Package name not found in ${cargoToml}`));
-							} else {
-								done(null, { isWorkspace: false, packageName: matches[2] });
-							}
 						}
 					},
 
 					(packageInfo, done) => {
 						if (fs.existsSync(cargoLock)) {
-							if (packageInfo.isWorkspace) {
-								// Update versions for all workspace members in Cargo.lock
-								let cargoLockContent = fs.readFileSync(cargoLock, 'utf8');
+							// Update versions for all members in Cargo.lock
+							let cargoLockContent = fs.readFileSync(cargoLock, 'utf8');
 
-								for (const member of packageInfo.members) {
-									cargoLockContent = cargoLockContent.replace(
-										new RegExp(
-											`(name\\s*=\\s*"${member}"[^[]*?version\\s*=\\s*)"[^"]*"`,
-											'g',
-										),
-										`$1"${cleanedVersion}"`,
-									);
-								}
-
-								fs.writeFileSync(cargoLock, cargoLockContent);
-								done(null);
-							} else {
-								// Update first `version = "..."` occurrence immediately after `name = "${packageName}"`
-								replace(
-									cargoLock,
+							for (const member of packageInfo.members) {
+								// Update first `version = "..."` occurrence immediately after `name = "${member}"`
+								cargoLockContent = cargoLockContent.replace(
 									new RegExp(
-										`(name\\s*=\\s*(?:"|')${packageInfo.packageName}(?:"|')[^[]+?version\\s*=\\s*)("|').*?\\2`,
-										'm',
+										`(name\\s*=\\s*"${member}"[^[]*?version\\s*=\\s*)"[^"]*"`,
+										'g',
 									),
-									'$1$2' + cleanedVersion + '$2',
-									(err) => {
-										return done(err || null);
-									},
+									`$1"${cleanedVersion}"`,
 								);
 							}
-						} else {
-							done(null);
+
+							fs.writeFileSync(cargoLock, cargoLockContent);
 						}
+						done(null, packageInfo.config);
 					},
 
-					(done) => {
+					(config, done) => {
 						// Update version in Cargo.toml - check for workspace or package section
-						const workspaceVersionRegex =
-							/(\[workspace\.package\][^[]+?version\s*=\s*)("|').*?\2/m;
-						const packageVersionRegex =
-							/(\[package\][^[]+?version\s*=\s*)("|').*?\2/m;
+						if (config.workspace != null && config.workspace.package != null) {
+							config.workspace.package.version = cleanedVersion;
+						}
 
-						// Try workspace section first
-						replace(
-							cargoToml,
-							workspaceVersionRegex,
-							'$1$2' + cleanedVersion + '$2',
-							(err) => {
-								if (err) {
-									// If workspace section not found, try package section
-									replace(
-										cargoToml,
-										packageVersionRegex,
-										'$1$2' + cleanedVersion + '$2',
-										done,
-									);
-								} else {
-									done(null);
-								}
-							},
-						);
+						if (config.package != null) {
+							config.package.version = cleanedVersion;
+						}
+
+						fs.writeFileSync(cargoToml, TOML.stringify(config));
+						done(null);
 					},
 				],
 				callback,

--- a/src/presets.js
+++ b/src/presets.js
@@ -1006,6 +1006,17 @@ module.exports = {
 					(contents, done) => {
 						// Check if this is a workspace
 						const workspaceMatch = contents.match(/\[workspace\]/m);
+						const packageMatch = contents.match(/\[package\]/m);
+
+						if (workspaceMatch && packageMatch) {
+							// Versionist doesn't support both workspace and package sections as both
+							// could have different versions and the module would not know which one to update
+							return done(
+								new Error(
+									`Only one of [workspace] or [package] Cargo.toml sections are supported by versionist.`,
+								),
+							);
+						}
 
 						if (workspaceMatch) {
 							// For workspaces, extract member names from the members array

--- a/src/presets.js
+++ b/src/presets.js
@@ -1015,7 +1015,7 @@ module.exports = {
 								const membersStr = membersMatch[1];
 								const memberMatches = membersStr.match(/"([^"]+)"/g);
 								if (memberMatches) {
-									const members = memberMatches.map(m => m.slice(1, -1));
+									const members = memberMatches.map((m) => m.slice(1, -1));
 									done(null, { isWorkspace: true, members });
 								} else {
 									done(null, { isWorkspace: true, members: [] });
@@ -1046,9 +1046,9 @@ module.exports = {
 									cargoLockContent = cargoLockContent.replace(
 										new RegExp(
 											`(name\\s*=\\s*"${member}"[^[]*?version\\s*=\\s*)"[^"]*"`,
-											'g'
+											'g',
 										),
-										`$1"${cleanedVersion}"`
+										`$1"${cleanedVersion}"`,
 									);
 								}
 
@@ -1075,8 +1075,10 @@ module.exports = {
 
 					(done) => {
 						// Update version in Cargo.toml - check for workspace or package section
-						const workspaceVersionRegex = /(\[workspace\.package\][^[]+?version\s*=\s*)("|').*?\2/m;
-						const packageVersionRegex = /(\[package\][^[]+?version\s*=\s*)("|').*?\2/m;
+						const workspaceVersionRegex =
+							/(\[workspace\.package\][^[]+?version\s*=\s*)("|').*?\2/m;
+						const packageVersionRegex =
+							/(\[package\][^[]+?version\s*=\s*)("|').*?\2/m;
 
 						// Try workspace section first
 						replace(
@@ -1095,7 +1097,7 @@ module.exports = {
 								} else {
 									done(null);
 								}
-							}
+							},
 						);
 					},
 				],

--- a/tests/presets.spec.js
+++ b/tests/presets.spec.js
@@ -1390,9 +1390,9 @@ describe('Presets', function () {
 							'name = "foo"',
 							'version = "1.0.0"',
 							'',
+							'[dependencies]',
 							'[dependencies.bar]',
 							'version = "2.0.0"',
-							'',
 						].join('\n'),
 					);
 				});
@@ -1414,9 +1414,9 @@ describe('Presets', function () {
 									'name = "foo"',
 									'version = "1.1.0"',
 									'',
+									'[dependencies]',
 									'[dependencies.bar]',
 									'version = "2.0.0"',
-									'',
 								].join('\n'),
 							);
 
@@ -1436,9 +1436,9 @@ describe('Presets', function () {
 									'name = "foo"',
 									'version = "1.0.0"',
 									'',
+									'[dependencies]',
 									'[dependencies.bar]',
 									'version = "2.0.0"',
-									'',
 								].join('\n'),
 							);
 
@@ -1475,9 +1475,9 @@ describe('Presets', function () {
 							'name = "foo"',
 							'version = "1.0.0"',
 							'',
+							'[dependencies]',
 							'[dependencies.bar]',
 							'version = "2.0.0"',
-							'',
 						].join('\n'),
 					);
 
@@ -1521,9 +1521,9 @@ describe('Presets', function () {
 									'name = "foo"',
 									'version = "1.0.1"',
 									'',
+									'[dependencies]',
 									'[dependencies.bar]',
 									'version = "2.0.0"',
-									'',
 								].join('\n'),
 							);
 
@@ -1565,9 +1565,9 @@ describe('Presets', function () {
 									'name = "foo"',
 									'version = "1.0.0"',
 									'',
+									'[dependencies]',
 									'[dependencies.bar]',
 									'version = "2.0.0"',
-									'',
 								].join('\n'),
 							);
 
@@ -1610,98 +1610,6 @@ describe('Presets', function () {
 							done();
 						},
 					);
-				});
-			});
-
-			describe('single-quotes in Cargo.toml and Cargo.lock', function () {
-				beforeEach(function () {
-					this.cwd = tmp.dirSync();
-					this.cargoToml = path.join(this.cwd.name, 'Cargo.toml');
-					this.cargoLock = path.join(this.cwd.name, 'Cargo.lock');
-
-					fs.writeFileSync(
-						this.cargoToml,
-						[
-							'[package]',
-							"name = 'foo'",
-							"version = '1.0.0'",
-							'',
-							'[dependencies.bar]',
-							"version = '2.0.0'",
-							'',
-						].join('\n'),
-					);
-
-					fs.writeFileSync(
-						this.cargoLock,
-						[
-							'[[package]]',
-							"name = 'bar'",
-							"version = '2.0.0'",
-							"source = 'registry+https://github.com/rust-lang/crates.io-index'",
-							'',
-							'[[package]]',
-							"name = 'foo'",
-							"version = '1.0.0'",
-							'dependencies = [',
-							" 'bar 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)',",
-							']',
-							'',
-							'[metadata]',
-							"'checksum bar 2.0.0 (registry+https://...)' = '...'",
-							'',
-						].join('\n'),
-					);
-				});
-
-				afterEach(function () {
-					fs.unlinkSync(this.cargoToml);
-					fs.unlinkSync(this.cargoLock);
-					this.cwd.removeCallback();
-				});
-
-				it('should be able to update the version (and preserve the single-quotes)', function (done) {
-					presets.updateVersion.cargo({}, this.cwd.name, '1.1.0', (error) => {
-						m.chai.expect(error).to.not.exist;
-
-						m.chai
-							.expect(fs.readFileSync(this.cargoToml, 'utf8'))
-							.to.equal(
-								[
-									'[package]',
-									"name = 'foo'",
-									"version = '1.1.0'",
-									'',
-									'[dependencies.bar]',
-									"version = '2.0.0'",
-									'',
-								].join('\n'),
-							);
-
-						m.chai
-							.expect(fs.readFileSync(this.cargoLock, 'utf8'))
-							.to.equal(
-								[
-									'[[package]]',
-									"name = 'bar'",
-									"version = '2.0.0'",
-									"source = 'registry+https://github.com/rust-lang/crates.io-index'",
-									'',
-									'[[package]]',
-									"name = 'foo'",
-									"version = '1.1.0'",
-									'dependencies = [',
-									" 'bar 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)',",
-									']',
-									'',
-									'[metadata]',
-									"'checksum bar 2.0.0 (registry+https://...)' = '...'",
-									'',
-								].join('\n'),
-							);
-
-						done();
-					});
 				});
 			});
 
@@ -1752,47 +1660,7 @@ describe('Presets', function () {
 						m.chai.expect(error).to.be.an.instanceof(Error);
 						m.chai
 							.expect(error.message)
-							.to.equal(`Package name not found in ${this.cargoToml}`);
-						done();
-					});
-				});
-			});
-
-			describe('missing target package name in Cargo.lock', function () {
-				beforeEach(function () {
-					this.cwd = tmp.dirSync();
-					this.cargoToml = path.join(this.cwd.name, 'Cargo.toml');
-					this.cargoLock = path.join(this.cwd.name, 'Cargo.lock');
-
-					fs.writeFileSync(
-						this.cargoToml,
-						['[package]', 'name = "foo"', 'version = "1.0.0"', ''].join('\n'),
-					);
-
-					fs.writeFileSync(
-						this.cargoLock,
-						[
-							'[[package]]',
-							'name = "bar"',
-							'version = "2.0.0"',
-							'source = "registry+https://github.com/rust-lang/crates.io-index"',
-							'',
-						].join('\n'),
-					);
-				});
-
-				afterEach(function () {
-					fs.unlinkSync(this.cargoToml);
-					fs.unlinkSync(this.cargoLock);
-					this.cwd.removeCallback();
-				});
-
-				it('should yield an error', function (done) {
-					presets.updateVersion.cargo({}, this.cwd.name, '1.0.1', (error) => {
-						m.chai.expect(error).to.be.an.instanceof(Error);
-						m.chai
-							.expect(error.message)
-							.to.equal(`Pattern does not match ${this.cargoLock}`);
+							.to.equal(`Missing property 'package.name' in Cargo.toml`);
 						done();
 					});
 				});
@@ -1826,57 +1694,7 @@ describe('Presets', function () {
 						m.chai.expect(error).to.be.an.instanceof(Error);
 						m.chai
 							.expect(error.message)
-							.to.equal(`Pattern does not match ${this.cargoToml}`);
-						done();
-					});
-				});
-			});
-
-			describe('missing version in Cargo.lock', function () {
-				beforeEach(function () {
-					this.cwd = tmp.dirSync();
-					this.cargoToml = path.join(this.cwd.name, 'Cargo.toml');
-					this.cargoLock = path.join(this.cwd.name, 'Cargo.lock');
-
-					fs.writeFileSync(
-						this.cargoToml,
-						[
-							'[package]',
-							'name = "foo"',
-							'version = "1.0.0"',
-							'',
-							'[dependencies.bar]',
-							'version = "2.0.0"',
-							'',
-						].join('\n'),
-					);
-
-					fs.writeFileSync(
-						this.cargoLock,
-						[
-							'[[package]]',
-							'name = "foo"',
-							'',
-							'[[package]]',
-							'name = "bar"',
-							'version = "2.0.0"',
-							'',
-						].join('\n'),
-					);
-				});
-
-				afterEach(function () {
-					fs.unlinkSync(this.cargoToml);
-					fs.unlinkSync(this.cargoLock);
-					this.cwd.removeCallback();
-				});
-
-				it('should yield an error', function (done) {
-					presets.updateVersion.cargo({}, this.cwd.name, '1.0.1', (error) => {
-						m.chai.expect(error).to.be.an.instanceof(Error);
-						m.chai
-							.expect(error.message)
-							.to.equal(`Pattern does not match ${this.cargoLock}`);
+							.to.equal(`Missing property 'package.version' in Cargo.toml`);
 						done();
 					});
 				});
@@ -1938,9 +1756,7 @@ describe('Presets', function () {
 						m.chai
 							.expect(fs.readFileSync(this.cargoToml, 'utf8'))
 							.to.equal(
-								['[package]', 'name = "foo"', 'version = "1.1.0"', ''].join(
-									'\n',
-								),
+								['[package]', 'name = "foo"', 'version = "1.1.0"'].join('\n'),
 							);
 
 						done();
@@ -2026,14 +1842,14 @@ describe('Presets', function () {
 							.to.equal(
 								[
 									'[workspace]',
-									'members = ["foo", "foo-derive"]',
+									'members = [ "foo", "foo-derive" ]',
 									'',
 									'[workspace.package]',
 									'version = "1.1.0"',
 									'',
+									'[dependencies]',
 									'[dependencies.bar]',
 									'version = "2.0.0"',
-									'',
 								].join('\n'),
 							);
 
@@ -2050,14 +1866,14 @@ describe('Presets', function () {
 							.to.equal(
 								[
 									'[workspace]',
-									'members = ["foo", "foo-derive"]',
+									'members = [ "foo", "foo-derive" ]',
 									'',
 									'[workspace.package]',
 									'version = "1.0.0"',
 									'',
+									'[dependencies]',
 									'[dependencies.bar]',
 									'version = "2.0.0"',
-									'',
 								].join('\n'),
 							);
 
@@ -2142,14 +1958,14 @@ describe('Presets', function () {
 							.to.equal(
 								[
 									'[workspace]',
-									'members = ["foo", "foo-derive"]',
+									'members = [ "foo", "foo-derive" ]',
 									'',
 									'[workspace.package]',
 									'version = "1.0.1"',
 									'',
+									'[dependencies]',
 									'[dependencies.bar]',
 									'version = "2.0.0"',
-									'',
 								].join('\n'),
 							);
 
@@ -2191,14 +2007,14 @@ describe('Presets', function () {
 							.to.equal(
 								[
 									'[workspace]',
-									'members = ["foo", "foo-derive"]',
+									'members = [ "foo", "foo-derive" ]',
 									'',
 									'[workspace.package]',
 									'version = "1.0.0"',
 									'',
+									'[dependencies]',
 									'[dependencies.bar]',
 									'version = "2.0.0"',
-									'',
 								].join('\n'),
 							);
 

--- a/tests/presets.spec.js
+++ b/tests/presets.spec.js
@@ -1948,6 +1948,49 @@ describe('Presets', function () {
 				});
 			});
 
+			describe('both workspace and package in Cargo.toml', function () {
+				beforeEach(function () {
+					this.cwd = tmp.dirSync();
+					this.cargoToml = path.join(this.cwd.name, 'Cargo.toml');
+
+					fs.writeFileSync(
+						this.cargoToml,
+						[
+							'[workspace]',
+							'members = ["foo", "foo-derive"]',
+							'',
+							'[package]',
+							'version = "1.0.0"',
+							'',
+							'[workspace.package]',
+							'version = "1.0.0"',
+							'',
+							'[dependencies]',
+							'name = "bar"',
+							'version = "2.0.0"',
+							'',
+						].join('\n'),
+					);
+				});
+
+				afterEach(function () {
+					fs.unlinkSync(this.cargoToml);
+					this.cwd.removeCallback();
+				});
+
+				it('should yield an error', function (done) {
+					presets.updateVersion.cargo({}, this.cwd.name, '1.1.0', (error) => {
+						m.chai.expect(error).to.be.an.instanceof(Error);
+						m.chai
+							.expect(error.message)
+							.to.equal(
+								`Only one of [workspace] or [package] Cargo.toml sections are supported by versionist.`,
+							);
+						done();
+					});
+				});
+			});
+
 			describe('well-formed Cargo.toml with workspace without a Cargo.lock', function () {
 				beforeEach(function () {
 					this.cwd = tmp.dirSync();


### PR DESCRIPTION
[Cargo workspaces](https://doc.rust-lang.org/book/ch14-03-cargo-workspaces.html) allow to have multiple crates in the same repository, to extend a library via optional features or helper packages. This PR adds support for a simple case of cargo workspaces where the same version is inherited by all sub-crates, allowing the workspace version and its members to be updated through this tool.


## Release notes

Add supports for a particular use case of [Cargo workspaces](https://doc.rust-lang.org/book/ch14-03-cargo-workspaces.html) where the version is managed via `[workspace.package]` and all the members have the version configured as `version = {workspace = true}`